### PR TITLE
feat: add first data-api schema example, tokens-by-address

### DIFF
--- a/data-api/.env.example
+++ b/data-api/.env.example
@@ -1,0 +1,1 @@
+ALCHEMY_API_KEY=

--- a/data-api/README.md
+++ b/data-api/README.md
@@ -1,0 +1,58 @@
+# Testing Data API Schemas
+
+This directory contains Valibot schemas and tests for Data API request and
+response payloads. The tests validate local JSON fixtures against the schemas so
+we can catch differences between the documented API shape, internal service
+responses, and the examples in this repo.
+
+## Pre-requisites
+
+Install Deno and confirm:
+```bash
+deno --version
+```
+
+## Run Fixture Tests
+
+From this directory:
+
+```bash
+cd /Users/sean.sing/Development/lab/data-api
+deno test --allow-read
+```
+
+To run only a specific schema test:
+
+```bash
+deno test --allow-read utils/schemas/portfolio/tokens-by-address.test.ts
+```
+
+These tests read files from their respective example `payloads/` and do not make network
+calls.
+
+## Run Live API Test
+
+The live API test is skipped by default. To enable it, create a local `.env`
+file:
+
+```bash
+cp .env.example .env
+```
+
+Then add your key:
+
+```bash
+ALCHEMY_API_KEY=your-api-key
+```
+
+Run the live test with Deno's `.env` loader:
+
+```bash
+deno test --env-file=.env --allow-env=ALCHEMY_API_KEY --allow-read --allow-net
+```
+
+The live test sends `payloads/portfolio/tokens-by-address/test-request.json` to
+the Portfolio API and validates the response with
+`TokensByAddressResponseSchema`.
+
+Do not commit a real API key.

--- a/data-api/deno.json
+++ b/data-api/deno.json
@@ -1,0 +1,6 @@
+{
+  "imports": {
+    "@valibot/valibot": "jsr:@valibot/valibot@^0.42.1",
+    "@std/assert": "jsr:@std/assert@^1.0.0"
+  }
+}

--- a/data-api/deno.lock
+++ b/data-api/deno.lock
@@ -1,0 +1,22 @@
+{
+  "version": "5",
+  "specifiers": {
+    "jsr:@std/assert@*": "1.0.19",
+    "jsr:@valibot/valibot@*": "0.42.1",
+    "jsr:@valibot/valibot@~0.42.1": "0.42.1"
+  },
+  "jsr": {
+    "@std/assert@1.0.19": {
+      "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e"
+    },
+    "@valibot/valibot@0.42.1": {
+      "integrity": "ba0f6f7964aaeec0e4b1f793d575061f325ae6254cbb9d7ff01fb65068a0a23b"
+    }
+  },
+  "workspace": {
+    "dependencies": [
+      "jsr:@std/assert@1",
+      "jsr:@valibot/valibot@~0.42.1"
+    ]
+  }
+}

--- a/data-api/payloads/portfolio/tokens-by-address/test-payload-multi-wallet-network.json
+++ b/data-api/payloads/portfolio/tokens-by-address/test-payload-multi-wallet-network.json
@@ -1,0 +1,1343 @@
+{
+  "data": {
+    "tokens": [
+      {
+        "address": "0x1e6e8695fab3eb382534915ea8d7cc1d1994b152",
+        "network": "eth-mainnet",
+        "tokenAddress": null,
+        "tokenBalance": "0x00000000000000000000000000000000000000000000000009cbebbc25efff3c",
+        "tokenMetadata": {
+          "symbol": null,
+          "decimals": null,
+          "name": null,
+          "logo": null
+        },
+        "tokenPrices": [
+          {
+            "currency": "usd",
+            "value": "1721.65",
+            "lastUpdatedAt": "2026-06-15T06:55:05.316Z"
+          }
+        ]
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": null,
+        "tokenBalance": "0x0000000000000000000000000000000000000000000000004ef31575f6e44b53",
+        "tokenMetadata": {
+          "symbol": null,
+          "decimals": null,
+          "name": null,
+          "logo": null
+        },
+        "tokenPrices": [
+          {
+            "currency": "usd",
+            "value": "1721.65",
+            "lastUpdatedAt": "2026-06-15T06:55:05.316Z"
+          }
+        ]
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "base-mainnet",
+        "tokenAddress": null,
+        "tokenBalance": "0x0000000000000000000000000000000000000000000000002b5bd34e90619268",
+        "tokenMetadata": {
+          "symbol": null,
+          "decimals": null,
+          "name": null,
+          "logo": null
+        },
+        "tokenPrices": [
+          {
+            "currency": "usd",
+            "value": "1721.65",
+            "lastUpdatedAt": "2026-06-15T06:55:05.316Z"
+          }
+        ]
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x000000000000e63d2c9c29d3edf6efb99071f92c",
+        "tokenBalance": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "tokenMetadata": {
+          "decimals": 18,
+          "logo": null,
+          "name": "Holy Trinity",
+          "symbol": "HOLY"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x00000000002514bf58ae82408e1e217f16a1dfa0",
+        "tokenBalance": "0x000000000000000000000000000000000000000000002a5a058fc295ed000000",
+        "tokenMetadata": {
+          "decimals": 18,
+          "logo": null,
+          "name": "Anonymous AI",
+          "symbol": "ANON"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x000000000072cd55f05d07ec75f33390fb0eaa97",
+        "tokenBalance": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "tokenMetadata": {
+          "decimals": 18,
+          "logo": null,
+          "name": "Lyra",
+          "symbol": "LYRA"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x0000000000c39a0f674c12a5e63eb8031b550b6f",
+        "tokenBalance": "0x00000000000000000000000000000000000000000000000324e964b3eca80000",
+        "tokenMetadata": {
+          "decimals": 18,
+          "logo": null,
+          "name": "",
+          "symbol": ""
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x0000000000c5dc95539589fbd24be07c6c14eca4",
+        "tokenBalance": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "tokenMetadata": {
+          "decimals": 18,
+          "logo": null,
+          "name": "Milady Cult Coin",
+          "symbol": "CULT"
+        },
+        "tokenPrices": [
+          {
+            "currency": "usd",
+            "value": "0.00014634831634721413",
+            "lastUpdatedAt": "2026-06-15T06:55:06Z"
+          }
+        ]
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "base-mainnet",
+        "tokenAddress": "0x0000000000dd2df17f17d075628c2c7bb430813d",
+        "tokenBalance": "0x0000000000000000000000000000000000000000033b190f9d089ef1f1800000",
+        "tokenMetadata": {
+          "decimals": 18,
+          "logo": null,
+          "name": "REPUT.ETH",
+          "symbol": "RPT"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x0000000000dec1295e1663e7e1916d0e80905d9d",
+        "tokenBalance": "0x0000000000000000000000000000000000000000000000878678326eac900000",
+        "tokenMetadata": {
+          "decimals": 18,
+          "logo": null,
+          "name": "01",
+          "symbol": "01"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x0000000000f593134dcf221a84c2fa0fc5c75bfc",
+        "tokenBalance": "0x00000000000000000000000000000000000000000000152d02c7e14af6800000",
+        "tokenMetadata": {
+          "decimals": 18,
+          "logo": null,
+          "name": "Anonymous AI",
+          "symbol": "ANON"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x00000000366b8a1ec86d6c8e00c861bf2245d946",
+        "tokenBalance": "0x000000000000000000000000000000000000000000000000000aa87bee538000",
+        "tokenMetadata": {
+          "decimals": 9,
+          "logo": null,
+          "name": "iPhone 15",
+          "symbol": "iPhone15"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x000000004bb4e57ca59cf7cfea73d57a34bf0776",
+        "tokenBalance": "0x00000000000000000000000000000000000000000000152d02c7e14af6800000",
+        "tokenMetadata": {
+          "decimals": 18,
+          "logo": null,
+          "name": "MUSHY",
+          "symbol": "MUSHY"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x00000000f9fd50c832d79facfe6f4e8ce90a5efb",
+        "tokenBalance": "0x0000000000000000000000000000000000000000014adf4b7320334b90000000",
+        "tokenMetadata": {
+          "decimals": 18,
+          "logo": null,
+          "name": "Polygon Token",
+          "symbol": "POL"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x0000003ceede5c40e5187784d3e8dd5b43dc85f6",
+        "tokenBalance": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "tokenMetadata": {
+          "decimals": 9,
+          "logo": null,
+          "name": "Cultel",
+          "symbol": "CULTEL"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x000000980d0be42ce4354a67458805f50578fa00",
+        "tokenBalance": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "tokenMetadata": {
+          "decimals": 18,
+          "logo": null,
+          "name": "ETH GUY",
+          "symbol": "ETHGUY"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x000000a1a6cb569ee64e1f8c3529390113e34cf8",
+        "tokenBalance": "0x000000000000000000000000000000000000000078b2ef682a5071579d3e6b16",
+        "tokenMetadata": {
+          "decimals": 18,
+          "logo": null,
+          "name": "OG",
+          "symbol": "OG"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x000000ddaab05b16aaab8d73e402f936d7dbaf73",
+        "tokenBalance": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "tokenMetadata": {
+          "decimals": 9,
+          "logo": null,
+          "name": "The Protocol",
+          "symbol": "THE"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x00000cc55035a11eec4ce5549d4aeb6c89f6c2a6",
+        "tokenBalance": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "tokenMetadata": {
+          "decimals": 9,
+          "logo": null,
+          "name": "Vit Guy",
+          "symbol": "VITGUY"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x00004963714f66aae8d08a744dcbd1f027cdc4de",
+        "tokenBalance": "0x000000000000000000000000000000000000000000000000058d15e176280000",
+        "tokenMetadata": {
+          "decimals": 9,
+          "logo": null,
+          "name": "Wally2.0",
+          "symbol": "WALLY2.0"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x0000bdaa645097ef80f9d475f341d0d107a45b3a",
+        "tokenBalance": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "tokenMetadata": {
+          "decimals": 18,
+          "logo": null,
+          "name": "Brainlet",
+          "symbol": "BRAINLET"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x0000cdb43f47fe3fac3979594443d058be6fcde0",
+        "tokenBalance": "0x00000000000000000000000000000000000000000000000123e98e4deff44000",
+        "tokenMetadata": {
+          "decimals": 9,
+          "logo": null,
+          "name": "Act I:The AI Prophecy",
+          "symbol": "ACT"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "base-mainnet",
+        "tokenAddress": "0x0004a2c7a40d97add19a428dae3fab4654c0c4a8",
+        "tokenBalance": "0x00000000000000000000000000000000000000000b5ca5de6326205cdee598d1",
+        "tokenMetadata": {
+          "decimals": 18,
+          "logo": null,
+          "name": "Meta Facebook Zuckerberg",
+          "symbol": "Zuckerberg"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x0005cf3a3b053e0f63f5781072298af5e2dfd77a",
+        "tokenBalance": "0x0000000000000000000000000000000000000002a7a94e5292bb5e3449000000",
+        "tokenMetadata": {
+          "decimals": 18,
+          "logo": null,
+          "name": "燃烧的豚林",
+          "symbol": "豚林"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "base-mainnet",
+        "tokenAddress": "0x001075b96b0505d14e0e2f338d79b32c7d875b3b",
+        "tokenBalance": "0x00000000000000000000000000000000000000000000153d00f0226793e4b8e7",
+        "tokenMetadata": {
+          "decimals": 18,
+          "logo": null,
+          "name": "Ethereum",
+          "symbol": "ETH"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x0013aa3a3f5157534f588a2764c18a7e42b3d9be",
+        "tokenBalance": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "tokenMetadata": {
+          "decimals": 9,
+          "logo": null,
+          "name": "Bitardio",
+          "symbol": "BITARDIO"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x00141a0769af0fc677396a9198b66081ffafca75",
+        "tokenBalance": "0x0000000000000000000000000000000000000000000000022b1c8c1227a00000",
+        "tokenMetadata": {
+          "decimals": 9,
+          "logo": null,
+          "name": "Omikami",
+          "symbol": "OMI"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x00154eb10dd99e26c697c4b0cacd2bea95b1842c",
+        "tokenBalance": "0x000000000000000000000000000000000000000000016f0cb9bf7cf6f3e7165d",
+        "tokenMetadata": {
+          "decimals": 18,
+          "logo": null,
+          "name": "GENIE 3",
+          "symbol": "GENIE"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "base-mainnet",
+        "tokenAddress": "0x0015b52614ee8f4f38e3c054193760eab9dc280c",
+        "tokenBalance": "0x000000000000000000000000000000000000000000000068605228e0d62618aa",
+        "tokenMetadata": {
+          "decimals": 18,
+          "logo": null,
+          "name": "Make Aliens Great Again",
+          "symbol": "MAGA"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "base-mainnet",
+        "tokenAddress": "0x0017c7cb3c8e620227ebd37043086637ecbf67aa",
+        "tokenBalance": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "tokenMetadata": {
+          "decimals": 8,
+          "logo": null,
+          "name": "Uni$",
+          "symbol": "Uni$"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x00208c5423461f39c9650825e5a02d56d8a5d1d2",
+        "tokenBalance": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "tokenMetadata": {
+          "decimals": 9,
+          "logo": null,
+          "name": "HarryPotterObamaSonicInu6900",
+          "symbol": "$ETH6900"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x0027449bf0887ca3e431d263ffdefb244d95b555",
+        "tokenBalance": "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        "tokenMetadata": {
+          "decimals": 18,
+          "logo": null,
+          "name": "Not",
+          "symbol": "NOT"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x00393a08aeb39157b24046addeb053a457c195fd",
+        "tokenBalance": "0x00000000000000000000000000000000000000000000000000b1a2bc2ec50000",
+        "tokenMetadata": {
+          "decimals": 9,
+          "logo": null,
+          "name": "ETHDog",
+          "symbol": "ETHDog"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "base-mainnet",
+        "tokenAddress": "0x00393c0b6e606ed053ee0abb5df2199f450685f1",
+        "tokenBalance": "0x00000000000000000000000000000000000000000000152d02c7e14af6800000",
+        "tokenMetadata": {
+          "decimals": 18,
+          "logo": null,
+          "name": "Fuck You Money",
+          "symbol": "GAMBL"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x003f410709f77b9078ce2d2468868ee5b1bd6848",
+        "tokenBalance": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "tokenMetadata": {
+          "decimals": 18,
+          "logo": null,
+          "name": "GemForge",
+          "symbol": "GEMFORGE"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x00413a4414ce203b7650c36ea7ff5c01ab4076aa",
+        "tokenBalance": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "tokenMetadata": {
+          "decimals": 18,
+          "logo": null,
+          "name": "柴犬コマリ",
+          "symbol": "KOMA"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x0042967a435ac637017387bb8f43e7d843f207bb",
+        "tokenBalance": "0x000000000000000000000000000000000000000000000000000089fce57e56f8",
+        "tokenMetadata": {
+          "decimals": 9,
+          "logo": null,
+          "name": "Cato The Cat",
+          "symbol": "CATO"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x0043943a2760fbd57f6e9efd46005319b2362640",
+        "tokenBalance": "0x0000000000000000000000000000000000000000000000000045aa90c70f21bc",
+        "tokenMetadata": {
+          "decimals": 8,
+          "logo": null,
+          "name": "DeepSeek R1",
+          "symbol": "DEEPSEEK R1"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x0047ebc9e3bb1120b70550b86db4e4e671905e55",
+        "tokenBalance": "0x0000000000000000000000000000000000000025de4203323f8ecb7e2d76670f",
+        "tokenMetadata": {
+          "decimals": 18,
+          "logo": null,
+          "name": "ShibFlix",
+          "symbol": "SBFLX"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x004be1384ccafdbd2e6bbd5aef123cfa28280b7f",
+        "tokenBalance": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "tokenMetadata": {
+          "decimals": 9,
+          "logo": null,
+          "name": "Year of the Snake",
+          "symbol": "SHE"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x004f747a91e05d0e2fbe8bf3cd39cdb2bcfab02c",
+        "tokenBalance": "0x0000000000000000000000000000000000000000000000008ac7230489e80000",
+        "tokenMetadata": {
+          "decimals": 18,
+          "logo": null,
+          "name": "TWEET",
+          "symbol": "TWEET"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x0050ec1a2cdceb2f4ea023b76f093482bc57a068",
+        "tokenBalance": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "tokenMetadata": {
+          "decimals": 18,
+          "logo": null,
+          "name": "KUMANEENE",
+          "symbol": "KUMANEENE"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x005d14e597f69b7f38c80657c1b6752c4cad7180",
+        "tokenBalance": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "tokenMetadata": {
+          "decimals": 9,
+          "logo": null,
+          "name": "Ethereum Mascot",
+          "symbol": "ETURUS"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x0061bca937894536e20ce28d1a2ca2b78a8f84da",
+        "tokenBalance": "0x0000000000000000000000000000000000000000000000004563918244f40000",
+        "tokenMetadata": {
+          "decimals": 9,
+          "logo": null,
+          "name": "Journey cat",
+          "symbol": "Cancy"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x006492d0102f0cc252aaf8683de85a0177941b59",
+        "tokenBalance": "0x00000000000000000000000000000000000000000000000000003b81e01b5611",
+        "tokenMetadata": {
+          "decimals": 9,
+          "logo": null,
+          "name": "Built To Climb",
+          "symbol": "BTC"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x0067394a6675620d0c6780faf9b7a3424de8518b",
+        "tokenBalance": "0x000000000000000000000000000000000000000000000000008e1bc9bf040000",
+        "tokenMetadata": {
+          "decimals": 9,
+          "logo": null,
+          "name": "Glamsterdam Flamingo",
+          "symbol": "FLAMINGO"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x0067cf4fe66725756c4f57d22597d9631cc4f0a8",
+        "tokenBalance": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "tokenMetadata": {
+          "decimals": 9,
+          "logo": null,
+          "name": "Roger",
+          "symbol": "ROGER"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x007114f052cbdb682a355f6259a6c1a89b6067e7",
+        "tokenBalance": "0x00000000000000000000000000000000000000000000000002c68af0bb140000",
+        "tokenMetadata": {
+          "decimals": 9,
+          "logo": null,
+          "name": "WORLD COMPUTER MONEY",
+          "symbol": "WCM"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x0077f8f6235178866f5f6273f5263cdcd3c88e01",
+        "tokenBalance": "0x00000000000000000000000000000000000000007f8bddc4cc1dfd0a20d60000",
+        "tokenMetadata": {
+          "decimals": 18,
+          "logo": null,
+          "name": "BASHAR DAO",
+          "symbol": "BASHAR"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x007ab742b874ee22393350a4f1f9d879699ead3b",
+        "tokenBalance": "0x00000000000000000000000000000000000000001137990927c533a1d0280000",
+        "tokenMetadata": {
+          "decimals": 18,
+          "logo": null,
+          "name": "MiladyCult",
+          "symbol": "CULT"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x007f252591528d326b2a73b366e5c6a0aa5128cc",
+        "tokenBalance": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "tokenMetadata": {
+          "decimals": 8,
+          "logo": null,
+          "name": "ratssats",
+          "symbol": "ratssats"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x007fb04d74ad455c7ff6b2a9c5f04b7b09915ac6",
+        "tokenBalance": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "tokenMetadata": {
+          "decimals": 9,
+          "logo": null,
+          "name": "KORAT NEKO",
+          "symbol": "KORAT"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x0083df2b079591216d352a1cc572c5e212667a9c",
+        "tokenBalance": "0x0000000000000000000000000000000000000000000000000038556dbb5b4690",
+        "tokenMetadata": {
+          "decimals": 9,
+          "logo": null,
+          "name": "Vixon",
+          "symbol": "VIX"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x00869e8e2e0343edd11314e6ccb0d78d51547ee5",
+        "tokenBalance": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "tokenMetadata": {
+          "decimals": 18,
+          "logo": null,
+          "name": "SuperGrok",
+          "symbol": "SUPERGROK"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "base-mainnet",
+        "tokenAddress": "0x00881016b7324678f4012fbca0c0267b69ebd10e",
+        "tokenBalance": "0x0000000000000000000000000000000000000000000000000de0b6b3a7640000",
+        "tokenMetadata": {
+          "decimals": 18,
+          "logo": null,
+          "name": "test",
+          "symbol": "RHUB"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "base-mainnet",
+        "tokenAddress": "0x008b2c67fe2e1a7a28105bd5e7d9760915907dbb",
+        "tokenBalance": "0x0000000000000000000000000000000000000000000000008ac7230489e80000",
+        "tokenMetadata": {
+          "decimals": 18,
+          "logo": null,
+          "name": "Ski Mask Trump",
+          "symbol": "SKITRUMP"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x008c5fd107cf62a2982ee934c2f856ebbd340f6f",
+        "tokenBalance": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "tokenMetadata": {
+          "decimals": 8,
+          "logo": null,
+          "name": "PIKO INU",
+          "symbol": "PIKO"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "base-mainnet",
+        "tokenAddress": "0x008d35764dcaa84e6d71bb29cb55b40d843eda0d",
+        "tokenBalance": "0x00000000000000000000000000000000000000000000000000000000000003e8",
+        "tokenMetadata": {
+          "decimals": 6,
+          "logo": null,
+          "name": "ACHIVX",
+          "symbol": "ACHIVX"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x009180d6f1390f0034366de2a33475b85600338b",
+        "tokenBalance": "0x0000000000000000000000000000000000000000000000000062a6b5bdae00fc",
+        "tokenMetadata": {
+          "decimals": 9,
+          "logo": null,
+          "name": "Memetopia",
+          "symbol": "MTOPIA"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x0091f0f8225b4ed55395ab6845c3d286066c0000",
+        "tokenBalance": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "tokenMetadata": {
+          "decimals": 0,
+          "logo": null,
+          "name": "Vitalik0",
+          "symbol": "V0"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x0098252ddbaa2065c309633e7eeb638addc9245a",
+        "tokenBalance": "0x0000000000000000000000000000000000000000000a5e81f5f9ff3ea8580000",
+        "tokenMetadata": {
+          "decimals": 18,
+          "logo": null,
+          "name": "happy birthday trump",
+          "symbol": "TRUMPHB"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x009881e5a5d978d7aa06f4d36e10bc6469a78c59",
+        "tokenBalance": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "tokenMetadata": {
+          "decimals": 9,
+          "logo": null,
+          "name": "Vitalik's T-REX",
+          "symbol": "VREX"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x0099c668b1691fd74e1b3fa2b4f55985265f574b",
+        "tokenBalance": "0x00000000000000000000000000000000000000000a6f027d929cf3dbf5e372cb",
+        "tokenMetadata": {
+          "decimals": 18,
+          "logo": null,
+          "name": "Puggy",
+          "symbol": "PUG"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x009ca253447783777fb4e861b089f7efe4e22faa",
+        "tokenBalance": "0x00000000000000000000000000000000000000000000000000470de4df820000",
+        "tokenMetadata": {
+          "decimals": 9,
+          "logo": null,
+          "name": "Decentralization obligatory, p",
+          "symbol": "DOPE"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x009d1a2129890429500f2ad828969d453c19b3af",
+        "tokenBalance": "0x000000000000000000000000000000000000000002e87669c308736a04000000",
+        "tokenMetadata": {
+          "decimals": 18,
+          "logo": null,
+          "name": "For The Sake Of Peace",
+          "symbol": "SACRIFICE"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x009e9d89bfaaf0d539450e7b8908703011704993",
+        "tokenBalance": "0x00000000000000000000000000000000000000000000000000000000c40a2840",
+        "tokenMetadata": {
+          "decimals": 6,
+          "logo": null,
+          "name": "APE/ETH",
+          "symbol": "claim at [apepool.org]"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x00a6ba94bbb5474725515de88fe04f854f2dcb12",
+        "tokenBalance": "0x00000000000000000000000000000000000000000000001b32cfc7b8b4ee4a8c",
+        "tokenMetadata": {
+          "decimals": 18,
+          "logo": null,
+          "name": "zOrg Shares",
+          "symbol": "ZORG"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "base-mainnet",
+        "tokenAddress": "0x00ac1ce5dfd82de5f82e587889cff4297dd107c5",
+        "tokenBalance": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "tokenMetadata": {
+          "decimals": 8,
+          "logo": null,
+          "name": "BENB",
+          "symbol": "BENB"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x00b6090bd7104c7fe6f77fefe6d16dce02636d63",
+        "tokenBalance": "0x000000000000000000000000000000000000000000000000002386f26fc10000",
+        "tokenMetadata": {
+          "decimals": 9,
+          "logo": null,
+          "name": "Heart-Chan",
+          "symbol": "HEART"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x00b6eb2452516b285a113727b6582a6d09dc857e",
+        "tokenBalance": "0x00000000000000000000000000000000000000000000000000aa21a880d37f24",
+        "tokenMetadata": {
+          "decimals": 6,
+          "logo": null,
+          "name": "Ethereum Mascot",
+          "symbol": "LESLIE"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "base-mainnet",
+        "tokenAddress": "0x00b7f751385788f640cf66ea73ded6ca9325ecbf",
+        "tokenBalance": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "tokenMetadata": {
+          "decimals": 8,
+          "logo": null,
+          "name": "CHAOS",
+          "symbol": "CHAOS"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x00bd73ff9c672e71e7d0e9436da86ff2e634b8e2",
+        "tokenBalance": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "tokenMetadata": {
+          "decimals": 8,
+          "logo": null,
+          "name": "Spaces",
+          "symbol": "Spaces"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x00bed1003e068400afaa4a8e97b415e1c482b481",
+        "tokenBalance": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "tokenMetadata": {
+          "decimals": 9,
+          "logo": null,
+          "name": "Matagi Inu",
+          "symbol": "MATAGI"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "base-mainnet",
+        "tokenAddress": "0x00c0943f0788cfd0782a893c0eefb42e154f15ae",
+        "tokenBalance": "0x000000000000000000000000000000000000000000000000000000012a05f200",
+        "tokenMetadata": {
+          "decimals": 8,
+          "logo": null,
+          "name": "friend.tech",
+          "symbol": "FRIEND"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x00c5ca160a968f47e7272a0cfcda36428f386cb6",
+        "tokenBalance": "0x00000000000000000000000000000000000000000000002a1f0a87470e840000",
+        "tokenMetadata": {
+          "decimals": 18,
+          "logo": "https://static.alchemyapi.io/images/assets/29110.png",
+          "name": "USDEBT",
+          "symbol": "USDEBT"
+        },
+        "tokenPrices": [
+          {
+            "currency": "usd",
+            "value": "0.0000000008099550875895599",
+            "lastUpdatedAt": "2026-06-09T00:04:36Z"
+          }
+        ]
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "base-mainnet",
+        "tokenAddress": "0x00c9c681d803d27d9c2e1e8612de073db0c5c390",
+        "tokenBalance": "0x000000000000000000000000000000000000000000000026de5fb52bd3140000",
+        "tokenMetadata": {
+          "decimals": 18,
+          "logo": null,
+          "name": "CrocWifHat",
+          "symbol": "CWH"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x00ce4037e09c4a98b13898a997a6aab1386e74b0",
+        "tokenBalance": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "tokenMetadata": {
+          "decimals": 8,
+          "logo": null,
+          "name": "WSHIA",
+          "symbol": "WSHIA"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x00d0f0250364c431376cc64aadd3aa13c6a8998d",
+        "tokenBalance": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "tokenMetadata": {
+          "decimals": 9,
+          "logo": null,
+          "name": "Smegma Dyte by Matt Furie",
+          "symbol": "SMEGMA"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x00d49a98a89104ff4ae7213371b68fd3f917cf38",
+        "tokenBalance": "0x0000000000000000000000000000000000000000a18f07d736b90be550000000",
+        "tokenMetadata": {
+          "decimals": 18,
+          "logo": null,
+          "name": "P’Benz",
+          "symbol": "P’Benz"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x00d7c198bfa2d7130391d705c73fdca0559cd8da",
+        "tokenBalance": "0x000000000000000000000000000000000000000000000000006a94d74f430000",
+        "tokenMetadata": {
+          "decimals": 9,
+          "logo": null,
+          "name": "SUNWUKONG",
+          "symbol": "SUNWUKONG"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "base-mainnet",
+        "tokenAddress": "0x00dde4d2f08497bcec6f5e0666f63e14b3a1dab9",
+        "tokenBalance": "0x000000000000000000000000000000000000000000029b825223498f225ed400",
+        "tokenMetadata": {
+          "decimals": 18,
+          "logo": null,
+          "name": "Dolphin Zone",
+          "symbol": "EEeEeEEEE"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x00e20f0423aa3f0137f0fae929ab6ce23420b836",
+        "tokenBalance": "0x000000000000000000000000000000000000000000000000002386f26fc10000",
+        "tokenMetadata": {
+          "decimals": 9,
+          "logo": null,
+          "name": "SpaceX Strategy",
+          "symbol": "SPCXSTR"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x00e2b6d170740c15bf9fb01d0b6e77c0d4510e32",
+        "tokenBalance": "0x0000000000000000000000000000000000000000000000000de0b6b3a7640000",
+        "tokenMetadata": {
+          "decimals": 18,
+          "logo": null,
+          "name": "Royal Dog",
+          "symbol": "DOG"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "base-mainnet",
+        "tokenAddress": "0x00e57ec29ef2ba7df07ad10573011647b2366f6d",
+        "tokenBalance": "0x0000000000000000000000000000000000000000000000056bc75e2d63100000",
+        "tokenMetadata": {
+          "decimals": 18,
+          "logo": null,
+          "name": "TOSHE",
+          "symbol": "TOSHE"
+        },
+        "tokenPrices": [
+          {
+            "currency": "usd",
+            "value": "0.00000000043216934461785765",
+            "lastUpdatedAt": "2026-06-15T06:49:21Z"
+          }
+        ]
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x00ead9dce996f326ee209dd87987a0e5c2666666",
+        "tokenBalance": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "tokenMetadata": {
+          "decimals": 9,
+          "logo": null,
+          "name": "Chinese Hana",
+          "symbol": "HENEI"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x00f00ab579e16bb2b6774487abbc16d98b2ab648",
+        "tokenBalance": "0x00000000000000000000000000000000000000000000000000715d9980b27a30",
+        "tokenMetadata": {
+          "decimals": 8,
+          "logo": null,
+          "name": "Pippin",
+          "symbol": "pippin"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x00f41627475e736f5ccdd53b979050fde6640a00",
+        "tokenBalance": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "tokenMetadata": {
+          "decimals": 18,
+          "logo": null,
+          "name": "OOMERS",
+          "symbol": "OOMERS"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "base-mainnet",
+        "tokenAddress": "0x00f5ea9658cb6646782b4fdfce902020700036a0",
+        "tokenBalance": "0x0000000000000000000000000000000000000000000000000de0b6b3a7640000",
+        "tokenMetadata": {
+          "decimals": 18,
+          "logo": null,
+          "name": "Handaru Fish",
+          "symbol": "FISH"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x00f7da38a3666de5ea2a7bd048fe7b6948610ac3",
+        "tokenBalance": "0x00000000000000000000000000000000000000000000000000071afd38a79750",
+        "tokenMetadata": {
+          "decimals": 9,
+          "logo": null,
+          "name": "Ghiblification 2.0",
+          "symbol": "GHIBLI2.0"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x010022baa9dd691bac7ff6ee7290dedce1f271ba",
+        "tokenBalance": "0x00000000000000000000000000000000000000000000000000470de4df820000",
+        "tokenMetadata": {
+          "decimals": null,
+          "logo": null,
+          "name": "",
+          "symbol": ""
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x010101015779f58115ad58a7e59ef3cab754fcd5",
+        "tokenBalance": "0x00000000000000000000000000000000000000000000043c33c1937564800000",
+        "tokenMetadata": {
+          "decimals": 18,
+          "logo": null,
+          "name": "阴阳",
+          "symbol": "阴阳"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x0101d9d7bd6a29c5954f6a9e33ca85d055b3c7fd",
+        "tokenBalance": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "tokenMetadata": {
+          "decimals": 18,
+          "logo": null,
+          "name": "LoFi Trump",
+          "symbol": "TRUMPFI"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x0112e088c443dd0f7efca7c4ee8e384d26829ad8",
+        "tokenBalance": "0x000000000000000000000000000000000000000000000000002386f26fc10000",
+        "tokenMetadata": {
+          "decimals": 9,
+          "logo": null,
+          "name": "Shibeus Maximus",
+          "symbol": "SHIBEUS"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "base-mainnet",
+        "tokenAddress": "0x011c8df04e6fb86940d02e85324d8f0555094e70",
+        "tokenBalance": "0x00000000000000000000000000000000000000000000010f0cf064dd59200000",
+        "tokenMetadata": {
+          "decimals": 18,
+          "logo": null,
+          "name": "chickeninpants",
+          "symbol": "CHIN"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x011df07a13691536d2e949d4dcb80a220f80982d",
+        "tokenBalance": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "tokenMetadata": {
+          "decimals": 9,
+          "logo": null,
+          "name": "Willy",
+          "symbol": "WILLY"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x012662dd2c6933211a8f493c61a2ca0024982a10",
+        "tokenBalance": "0x0000000000000000000000000000000000000030f34ce4f91da49a34cc0a3a25",
+        "tokenMetadata": {
+          "decimals": 18,
+          "logo": null,
+          "name": "Pepe Tokens",
+          "symbol": "PEPE"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "base-mainnet",
+        "tokenAddress": "0x0129614474d4b1df7053cc18c4e1cb646c563332",
+        "tokenBalance": "0x0000000000000000000000000000000000000000000000000de0b6b3a7640000",
+        "tokenMetadata": {
+          "decimals": 18,
+          "logo": null,
+          "name": "PimpFun",
+          "symbol": "PIMP"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x0129952909bdd559273a4627128476486a9d537a",
+        "tokenBalance": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "tokenMetadata": {
+          "decimals": 6,
+          "logo": null,
+          "name": "Tеther USD",
+          "symbol": "USDТ"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "base-mainnet",
+        "tokenAddress": "0x013658fd9a524d7f700f143822c59979cacf75ea",
+        "tokenBalance": "0x0000000000000000000000000000000000000000000000000000000000000a44",
+        "tokenMetadata": {
+          "decimals": null,
+          "logo": null,
+          "name": "$UNI",
+          "symbol": "Visit https://dropuni.xyz to claim airdrop"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x013bb7458f51b2e4c06eed814b8ef353dac947e9",
+        "tokenBalance": "0x0000000000000000000000000000000000000000027ac48c6bd0c66802a96045",
+        "tokenMetadata": {
+          "decimals": 18,
+          "logo": null,
+          "name": "SEGA Metaverse",
+          "symbol": "SEGA"
+        },
+        "tokenPrices": []
+      }
+    ],
+    "pageKey": "656b49ad-e8fa-4d32-abf6-044f85e79db9"
+  }
+}

--- a/data-api/payloads/portfolio/tokens-by-address/test-payload-single-wallet-network.json
+++ b/data-api/payloads/portfolio/tokens-by-address/test-payload-single-wallet-network.json
@@ -1,0 +1,77 @@
+{
+  "data": {
+    "tokens": [
+      {
+        "address": "0x1e6e8695fab3eb382534915ea8d7cc1d1994b152",
+        "network": "eth-mainnet",
+        "tokenAddress": null,
+        "tokenBalance": "0x00000000000000000000000000000000000000000000000009cbebbc25efff3c",
+        "tokenMetadata": {
+          "symbol": null,
+          "decimals": null,
+          "name": null,
+          "logo": null
+        },
+        "tokenPrices": [
+          {
+            "currency": "usd",
+            "value": "1721.65",
+            "lastUpdatedAt": "2026-06-15T06:54:18.742Z"
+          }
+        ]
+      },
+      {
+        "address": "0x1e6e8695fab3eb382534915ea8d7cc1d1994b152",
+        "network": "eth-mainnet",
+        "tokenAddress": "0x70a6d0d1561ba98711e935a76b1c167c612978a2",
+        "tokenBalance": "0x0000000000000000000000000000000000000000000000000000000005d03e4e",
+        "tokenMetadata": {
+          "decimals": 9,
+          "logo": null,
+          "name": "dragonflyprotocol.com",
+          "symbol": "DFLY"
+        },
+        "tokenPrices": []
+      },
+      {
+        "address": "0x1e6e8695fab3eb382534915ea8d7cc1d1994b152",
+        "network": "eth-mainnet",
+        "tokenAddress": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+        "tokenBalance": "0x00000000000000000000000000000000000000000000000000000000017ab20c",
+        "tokenMetadata": {
+          "decimals": 6,
+          "logo": "https://static.alchemyapi.io/images/assets/3408.png",
+          "name": "USDC",
+          "symbol": "USDC"
+        },
+        "tokenPrices": [
+          {
+            "currency": "usd",
+            "value": "0.9998",
+            "lastUpdatedAt": "2026-06-15T06:52:55.324Z"
+          }
+        ]
+      },
+      {
+        "address": "0x1e6e8695fab3eb382534915ea8d7cc1d1994b152",
+        "network": "eth-mainnet",
+        "tokenAddress": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "tokenBalance": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "tokenMetadata": {
+          "decimals": 18,
+          "logo": "https://static.alchemyapi.io/images/assets/2396.png",
+          "name": "WETH",
+          "symbol": "WETH"
+        },
+        "tokenPrices": [
+          {
+            "currency": "usd",
+            "value": "1719.6172692579798",
+            "lastUpdatedAt": "2026-06-15T06:52:52Z"
+          }
+        ]
+      }
+    ],
+    "pageKey": null
+  }
+}

--- a/data-api/payloads/portfolio/tokens-by-address/test-request.json
+++ b/data-api/payloads/portfolio/tokens-by-address/test-request.json
@@ -1,0 +1,22 @@
+{
+  "addresses": [
+    {
+      "address": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
+      "networks": [
+        "eth-mainnet",
+        "base-mainnet"
+      ]
+    },
+    {
+      "address": "0x1E6E8695FAb3Eb382534915eA8d7Cc1D1994B152",
+      "networks": [
+        "eth-mainnet",
+        "base-mainnet"
+      ]
+    }
+  ],
+  "withMetadata": true,
+  "withPrices": true,
+  "includeNativeTokens": true,
+  "includeErc20Tokens": true
+}

--- a/data-api/utils/schemas/portfolio/tokens-by-address.test.ts
+++ b/data-api/utils/schemas/portfolio/tokens-by-address.test.ts
@@ -1,0 +1,99 @@
+import { assert } from "jsr:@std/assert/assert";
+import { safeParse } from "jsr:@valibot/valibot";
+import {
+  TokensByAddressRequestSchema,
+  TokensByAddressResponseSchema,
+} from "./tokens-by-address.ts";
+
+const responseFixturePaths = [
+  "./payloads/portfolio/tokens-by-address/test-payload-single-wallet-network.json",
+  "./payloads/portfolio/tokens-by-address/test-payload-multi-wallet-network.json",
+];
+const requestFixturePath =
+  "./payloads/portfolio/tokens-by-address/test-request.json";
+
+const alchemyApiKeyEnvVar = "ALCHEMY_API_KEY";
+const alchemyApiKeyPermission = Deno.permissions.querySync({
+  name: "env",
+  variable: alchemyApiKeyEnvVar,
+});
+const alchemyApiKey = alchemyApiKeyPermission.state === "granted"
+  ? Deno.env.get(alchemyApiKeyEnvVar)?.trim() ?? ""
+  : "";
+const shouldRunLiveApiTest = alchemyApiKey.length > 0;
+
+// Test request fixture
+Deno.test("tokens by address request fixture is valid", async () => {
+  const payload = JSON.parse(await Deno.readTextFile(requestFixturePath));
+
+  const result = safeParse(TokensByAddressRequestSchema, payload);
+
+  assert(result.success, JSON.stringify(result.issues, null, 2));
+});
+
+// Test response fixtures
+for (const fixturePath of responseFixturePaths) {
+  Deno.test(`tokens by address response fixture is valid: ${fixturePath}`, async () => {
+    const payload = JSON.parse(await Deno.readTextFile(fixturePath));
+
+    const result = safeParse(TokensByAddressResponseSchema, payload);
+
+    assert(result.success, JSON.stringify(result.issues, null, 2));
+  });
+}
+
+Deno.test({
+  name: "tokens by address live API response is valid",
+  // Not ignored if an API key exists
+  ignore: !shouldRunLiveApiTest,
+  async fn() {
+    const requestPayload = JSON.parse(
+      await Deno.readTextFile(requestFixturePath),
+    );
+    const response = await fetch(
+      `https://api.g.alchemy.com/data/v1/${
+        encodeURIComponent(alchemyApiKey.trim())
+      }/assets/tokens/by-address`,
+      {
+        method: "POST",
+        headers: {
+          accept: "application/json",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify(requestPayload),
+      },
+    );
+    const responseText = await response.text();
+
+    // Log data from response
+    try {
+      const parsed = JSON.parse(responseText);
+      console.log(
+        "Total tokens returned:",
+        parsed?.data?.tokens?.length ?? "No tokens",
+      );
+      console.log();
+      // console.log page key if any
+      console.log("Page key:", parsed?.data?.pageKey ?? "No page key");
+
+      // If there is page key, include in the fixture to test next call
+      if (parsed?.data?.pageKey) {
+        console.log("- TIP: Update the request fixture with 'pageKey' to test the next page's payload if needed. Defaults to 100 per page.");
+      }
+    } catch (e) {
+      console.warn("Failed to parse response JSON for logging:", e);
+    }
+
+    // Ensure response successful
+    assert(
+      response.ok,
+      `Expected 2xx response, got ${response.status}: ${responseText}`,
+    );
+
+    // Ensure payload matches response schema
+    const payload = JSON.parse(responseText);
+    const result = safeParse(TokensByAddressResponseSchema, payload);
+
+    assert(result.success, JSON.stringify(result.issues, null, 2));
+  },
+});

--- a/data-api/utils/schemas/portfolio/tokens-by-address.ts
+++ b/data-api/utils/schemas/portfolio/tokens-by-address.ts
@@ -1,0 +1,71 @@
+import {
+  array,
+  boolean,
+  type InferInput,
+  type InferOutput,
+  isoTimestamp,
+  null_,
+  number,
+  optional,
+  pipe,
+  strictObject,
+  string,
+  union,
+} from "jsr:@valibot/valibot";
+
+const WalletAddress = string();
+const Network = string();
+
+const AddressRequestSchema = strictObject({
+  address: WalletAddress,
+  networks: array(Network),
+});
+
+export const TokensByAddressRequestSchema = strictObject({
+  addresses: array(
+    AddressRequestSchema,
+  ),
+  withMetadata: optional(boolean()),
+  withPrices: optional(boolean()),
+  includeNativeTokens: optional(boolean()),
+  includeErc20Tokens: optional(boolean()),
+  pageKey: optional(string()),
+});
+
+const TokenMetadataSchema = strictObject({
+  decimals: union([number(), null_()]),
+  logo: union([string(), null_()]),
+  name: union([string(), null_()]),
+  symbol: union([string(), null_()]),
+});
+
+const TokenPriceSchema = strictObject({
+  currency: string(),
+  value: string(),
+  // Check that it is a string, and ISO format
+  lastUpdatedAt: pipe(string(), isoTimestamp()),
+});
+
+const TokenSchema = strictObject({
+  network: Network,
+  address: WalletAddress,
+  tokenAddress: union([string(), null_()]),
+  tokenBalance: union([string(), null_()]),
+  tokenMetadata: optional(TokenMetadataSchema),
+  tokenPrices: optional(array(TokenPriceSchema)),
+});
+
+export const TokensByAddressResponseSchema = strictObject({
+  data: strictObject({
+    tokens: array(TokenSchema),
+    pageKey: union([string(), null_()]),
+  })
+});
+
+export type TokensByAddressRequest = InferInput<
+  typeof TokensByAddressRequestSchema
+>;
+
+export type TokensByAddressResponse = InferOutput<
+  typeof TokensByAddressResponseSchema
+>;


### PR DESCRIPTION
PR to add first `data-api `schema verification example using Valibot and [tokens-by-address](https://www.alchemy.com/docs/data/portfolio-apis/portfolio-api-endpoints/portfolio-api-endpoints/get-tokens-by-address). 

- Includes two approaches to test requests and response via defined JSON fixtures or live API call if API key is provided in `.env`. 